### PR TITLE
unix socket server

### DIFF
--- a/id/siegfried.py
+++ b/id/siegfried.py
@@ -1,23 +1,15 @@
 from __future__ import print_function
  
 import socket
-import subprocess
 import sys
  
-def file_tool(path):
-    return subprocess.check_output(['file', path]).strip()
-    
 def main(path):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
         sock.connect('/tmp/siegfried')
         sock.sendall(path)
         reply = sock.recv(1024)
-        if reply.startswith('e'):
-            if reply.startswith('error: format unknown'):
-                if "text" in file_tool(path):
-                    print("x-fmt/111")
-                    return 0
+        if reply.startswith('error'):
             print("Siegfried sent {}.".format(reply), file=sys.stderr)
             return 1
         else:


### PR DESCRIPTION
I added an -fpr flag to sf v1.1 (but only when built with archivematica tag). This is a simple server that just implements the FPR interface (it only sends puid + error message) and runs on unix sockets - so faster than the http/json approach.

This python script is a client for the -fpr server. I've copied most of Misty's existing script for this with a slight change: on multiple matches this script will return an error rather than giving the first result (I feel this is safer bc when you get multiple matches - which only happens for results that are matched on extension only - they all have equal weight).

Hope this all makes sense!
