### PR TITLE
FITS: replace with script to write to named pipe

### DIFF
--- a/characterization/fits.sh
+++ b/characterization/fits.sh
@@ -1,1 +1,8 @@
-ng edu.harvard.hul.ois.fits.Fits -i %relativeLocation%
+set -euo pipefail
+IFS=$'\n\t'
+
+tempdir=$(mktemp -d /tmp/fits.XXXXXX)
+ng edu.harvard.hul.ois.fits.Fits -i "%relativeLocation%" -o "$tempdir/fits.xml" >/dev/null
+cat "$tempdir/fits.xml"
+
+rm -r "$tempdir"


### PR DESCRIPTION
This fixes the issue we've had where FITS may inadvertantly pollute its stdout with debug output, for instance [#8610](https://projects.artefactual.com/issues/8610).

Fixes [#8647](https://projects.artefactual.com/issues/8647).
